### PR TITLE
Add Commands to manage (close & lock) Threads for Thread Owners

### DIFF
--- a/Interactions/SlashCommands/Management/closethread.js
+++ b/Interactions/SlashCommands/Management/closethread.js
@@ -1,0 +1,123 @@
+const { ChatInputCommandInteraction, ChatInputApplicationCommandData, ApplicationCommandType, AutocompleteInteraction, PermissionFlagsBits, ChannelType } = require("discord.js");
+const { localize } = require("../../../BotModules/LocalizationModule");
+const { fetchDisplayName } = require("../../../constants");
+const { LogToUserInteraction } = require("../../../BotModules/LoggingModule");
+
+// Just to make it easy for me lol
+const ThreadTypes = [ ChannelType.AnnouncementThread, ChannelType.PrivateThread, ChannelType.PublicThread ];
+
+module.exports = {
+    // Command's Name
+    //     Use full lowercase
+    Name: "closethread",
+
+    // Command's Description
+    Description: `Close the Thread/Post this Command is used in`,
+
+    // Command's Localised Descriptions
+    LocalisedDescriptions: {
+        'en-GB': `Close the Thread/Post this Command is used in`,
+        'en-US': `Close the Thread/Post this Command is used in`
+    },
+
+    // Command's Category
+    Category: "MANAGEMENT",
+
+    // Cooldown, in seconds
+    //     Defaults to 3 seconds if missing
+    Cooldown: 15,
+
+    // Cooldowns for specific subcommands and/or subcommand-groups
+    //     IF SUBCOMMAND: name as "subcommandName"
+    //     IF SUBCOMMAND GROUP: name as "subcommandGroupName_subcommandName"
+    SubcommandCooldown: {
+        "example": 3
+    },
+
+    // Scope of Command's usage
+    //     One of the following: DM, GUILD, ALL
+    Scope: "GUILD",
+
+    // Scope of specific Subcommands Usage
+    //     One of the following: DM, GUILD, ALL
+    //     IF SUBCOMMAND: name as "subcommandName"
+    //     IF SUBCOMMAND GROUP: name as "subcommandGroupName_subcommandName"
+    SubcommandScope: {
+        "example": "GUILD"
+    },
+
+
+
+    /**
+     * Returns data needed for registering Slash Command onto Discord's API
+     * @returns {ChatInputApplicationCommandData}
+     */
+    registerData()
+    {
+        /** @type {ChatInputApplicationCommandData} */
+        const Data = {};
+
+        Data.name = this.Name;
+        Data.description = this.Description;
+        Data.descriptionLocalizations = this.LocalisedDescriptions;
+        Data.type = ApplicationCommandType.ChatInput;
+        Data.dmPermission = false;
+
+        return Data;
+    },
+
+
+
+    /**
+     * Executes the Slash Command
+     * @param {ChatInputCommandInteraction} interaction 
+     */
+    async execute(interaction)
+    {
+        await interaction.deferReply({ ephemeral: true });
+
+        // Reject if used outside of Threads/Posts
+        if ( !ThreadTypes.includes(interaction.channel.type) ) { await interaction.editReply({ content: localize(interaction.locale, 'CLOSETHREAD_COMMAND_ERROR_NOT_IN_THREAD') }); return; }
+
+        // Ensure HeccBot has permissions
+        if ( !interaction.appPermissions.has(PermissionFlagsBits.ManageThreads) ) { await interaction.editReply({ content: localize(interaction.locale, 'CLOSETHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION') }); return; }
+
+        // Ensure Command User is Thread Owner
+        if ( interaction.channel.ownerId !== interaction.user.id )
+        {
+            // If not Thread Owner, check for "Manage Threads" Permission
+            if ( !interaction.memberPermissions.has(PermissionFlagsBits.ManageThreads) )
+            {
+                await interaction.editReply({ content: localize(interaction.locale, 'CLOSETHREAD_COMMAND_ERROR_NOT_THREAD_OWNER') });
+                return;
+            }
+        }
+
+
+        // Attempt to close Thread
+        await interaction.channel.setArchived(true, localize(interaction.guildLocale, 'CLOSETHREAD_COMMAND_AUDIT_LOG', fetchDisplayName(interaction.user, true)))
+        .then(async () => {
+            // Success, ACK
+            await interaction.editReply({ content: localize(interaction.locale, 'CLOSETHREAD_COMMAND_SUCCESS_THREAD') });
+            return;
+        })
+        .catch(async err => {
+            // Error
+            await LogToUserInteraction(interaction, null, err);
+            return;
+        });
+
+        return;
+    },
+
+
+
+    /**
+     * Handles given Autocomplete Interactions for any Options in this Slash CMD that uses it
+     * @param {AutocompleteInteraction} interaction 
+     */
+    async autocomplete(interaction)
+    {
+        //.
+    }
+}

--- a/Interactions/SlashCommands/Management/lockthread.js
+++ b/Interactions/SlashCommands/Management/lockthread.js
@@ -1,0 +1,124 @@
+const { ChatInputCommandInteraction, ChatInputApplicationCommandData, ApplicationCommandType, AutocompleteInteraction, PermissionFlagsBits, ChannelType } = require("discord.js");
+const { localize } = require("../../../BotModules/LocalizationModule");
+const { fetchDisplayName } = require("../../../constants");
+const { LogToUserInteraction } = require("../../../BotModules/LoggingModule");
+
+// Just to make it easy for me lol
+const ThreadTypes = [ ChannelType.AnnouncementThread, ChannelType.PrivateThread, ChannelType.PublicThread ];
+
+module.exports = {
+    // Command's Name
+    //     Use full lowercase
+    Name: "lockthread",
+
+    // Command's Description
+    Description: `Lock the Thread/Post this Command is used in, preventing non-Moderators from reopening it`,
+
+    // Command's Localised Descriptions
+    LocalisedDescriptions: {
+        'en-GB': `Lock the Thread/Post this Command is used in, preventing non-Moderators from reopening it`,
+        'en-US': `Lock the Thread/Post this Command is used in, preventing non-Moderators from reopening it`
+    },
+
+    // Command's Category
+    Category: "MANAGEMENT",
+
+    // Cooldown, in seconds
+    //     Defaults to 3 seconds if missing
+    Cooldown: 15,
+
+    // Cooldowns for specific subcommands and/or subcommand-groups
+    //     IF SUBCOMMAND: name as "subcommandName"
+    //     IF SUBCOMMAND GROUP: name as "subcommandGroupName_subcommandName"
+    SubcommandCooldown: {
+        "example": 3
+    },
+
+    // Scope of Command's usage
+    //     One of the following: DM, GUILD, ALL
+    Scope: "GUILD",
+
+    // Scope of specific Subcommands Usage
+    //     One of the following: DM, GUILD, ALL
+    //     IF SUBCOMMAND: name as "subcommandName"
+    //     IF SUBCOMMAND GROUP: name as "subcommandGroupName_subcommandName"
+    SubcommandScope: {
+        "example": "GUILD"
+    },
+
+
+
+    /**
+     * Returns data needed for registering Slash Command onto Discord's API
+     * @returns {ChatInputApplicationCommandData}
+     */
+    registerData()
+    {
+        /** @type {ChatInputApplicationCommandData} */
+        const Data = {};
+
+        Data.name = this.Name;
+        Data.description = this.Description;
+        Data.descriptionLocalizations = this.LocalisedDescriptions;
+        Data.type = ApplicationCommandType.ChatInput;
+        Data.dmPermission = false;
+        Data.defaultMemberPermissions = PermissionFlagsBits.ManageThreads;
+
+        return Data;
+    },
+
+
+
+    /**
+     * Executes the Slash Command
+     * @param {ChatInputCommandInteraction} interaction 
+     */
+    async execute(interaction)
+    {
+        await interaction.deferReply({ ephemeral: true });
+
+        // Reject if used outside of Threads/Posts
+        if ( !ThreadTypes.includes(interaction.channel.type) ) { await interaction.editReply({ content: localize(interaction.locale, 'LOCKTHREAD_COMMAND_ERROR_NOT_IN_THREAD') }); return; }
+
+        // Ensure HeccBot has permissions
+        if ( !interaction.appPermissions.has(PermissionFlagsBits.ManageThreads) ) { await interaction.editReply({ content: localize(interaction.locale, 'LOCKTHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION') }); return; }
+
+        // Ensure Command User is Thread Owner
+        if ( interaction.channel.ownerId !== interaction.user.id )
+        {
+            // If not Thread Owner, check for "Manage Threads" Permission
+            if ( !interaction.memberPermissions.has(PermissionFlagsBits.ManageThreads) )
+            {
+                await interaction.editReply({ content: localize(interaction.locale, 'LOCKTHREAD_COMMAND_ERROR_NOT_THREAD_OWNER') });
+                return;
+            }
+        }
+
+
+        // Attempt to close Thread
+        await interaction.channel.setLocked(true, localize(interaction.guildLocale, 'LOCKTHREAD_COMMAND_AUDIT_LOG', fetchDisplayName(interaction.user, true)))
+        .then(async () => {
+            // Success, ACK
+            await interaction.editReply({ content: localize(interaction.locale, 'LOCKTHREAD_COMMAND_SUCCESS_THREAD') });
+            return;
+        })
+        .catch(async err => {
+            // Error
+            await LogToUserInteraction(interaction, null, err);
+            return;
+        });
+
+        return;
+    },
+
+
+
+    /**
+     * Handles given Autocomplete Interactions for any Options in this Slash CMD that uses it
+     * @param {AutocompleteInteraction} interaction 
+     */
+    async autocomplete(interaction)
+    {
+        //.
+    }
+}

--- a/Locales/en-GB.js
+++ b/Locales/en-GB.js
@@ -901,4 +901,14 @@ These are Commands used on a specific User in Servers, and can be found (providi
     CLOSETHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
     CLOSETHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can close this Thread/Post.`,
     CLOSETHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to close Threads/Posts for you.`,
+
+
+
+    // ******* LOCK THREAD COMMAND
+    LOCKTHREAD_COMMAND_SUCCESS_THREAD: `Successfully locked this Thread/Post.`,
+    LOCKTHREAD_COMMAND_AUDIT_LOG: `Thread/Post locked by {{0}}`,
+
+    LOCKTHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
+    LOCKTHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can lock this Thread/Post.`,
+    LOCKTHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to lock Threads/Posts for you.`,
 };

--- a/Locales/en-GB.js
+++ b/Locales/en-GB.js
@@ -891,4 +891,14 @@ These are Commands used on a specific User in Servers, and can be found (providi
     ANIMAL_COMMAND_DOG_SOURCE_FOOTER: `Sourced from random.dog`,
 
     ANIMAL_COMMAND_ERROR_DOG_NOT_FOUND: `Sorry, I'm not able to fetch a random dog picture at this time.\nPlease wait a few minutes and try again later.`,
+
+
+
+    // ******* CLOSE THREAD COMMAND
+    CLOSETHREAD_COMMAND_SUCCESS_THREAD: `Successfully closed this Thread/Post.`,
+    CLOSETHREAD_COMMAND_AUDIT_LOG: `Thread/Post closed by {{0}}`,
+
+    CLOSETHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
+    CLOSETHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can close this Thread/Post.`,
+    CLOSETHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to close Threads/Posts for you.`,
 };

--- a/Locales/en-US.js
+++ b/Locales/en-US.js
@@ -901,4 +901,14 @@ These are Commands used on a specific User in Servers, and can be found (providi
     CLOSETHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
     CLOSETHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can close this Thread/Post.`,
     CLOSETHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to close Threads/Posts for you.`,
+
+
+
+    // ******* LOCK THREAD COMMAND
+    LOCKTHREAD_COMMAND_SUCCESS_THREAD: `Successfully locked this Thread/Post.`,
+    LOCKTHREAD_COMMAND_AUDIT_LOG: `Thread/Post locked by {{0}}`,
+
+    LOCKTHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
+    LOCKTHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can lock this Thread/Post.`,
+    LOCKTHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to lock Threads/Posts for you.`,
 };

--- a/Locales/en-US.js
+++ b/Locales/en-US.js
@@ -891,4 +891,14 @@ These are Commands used on a specific User in Servers, and can be found (providi
     ANIMAL_COMMAND_DOG_SOURCE_FOOTER: `Sourced from random.dog`,
 
     ANIMAL_COMMAND_ERROR_DOG_NOT_FOUND: `Sorry, I'm not able to fetch a random dog picture at this time.\nPlease wait a few minutes and try again later.`,
+    
+
+
+    // ******* CLOSE THREAD COMMAND
+    CLOSETHREAD_COMMAND_SUCCESS_THREAD: `Successfully closed this Thread/Post.`,
+    CLOSETHREAD_COMMAND_AUDIT_LOG: `Thread/Post closed by {{0}}`,
+
+    CLOSETHREAD_COMMAND_ERROR_NOT_IN_THREAD: `Sorry, this Command can only be used inside of Threads and Forum/Media Posts.`,
+    CLOSETHREAD_COMMAND_ERROR_NOT_THREAD_OWNER: `Sorry, only the owner of this Thread/Post (or those with "**Manage Threads & Posts**" Permission) can close this Thread/Post.`,
+    CLOSETHREAD_COMMAND_ERROR_MISSING_MANAGE_THREADS_PERMISSION: `Sorry, HeccBot needs the "**Manage Threads & Posts** Permission in order to close Threads/Posts for you.`,
 };


### PR DESCRIPTION
Adds the following commands:
- `/closethread`
- `/lockthread`

for allowing Thread Owners to close/lock their own Threads, without needing the `MANAGE_THREADS` Permission.

> [!NOTE]
> `/lockthread` will, by default, be restricted to only be usable by those with `MANAGE_THREADS` Permission.